### PR TITLE
모임 리스트 요청 API 리팩토링

### DIFF
--- a/src/api/meeting/meetingController.js
+++ b/src/api/meeting/meetingController.js
@@ -52,8 +52,8 @@ exports.featchMeeting = async (req, res) => {
     if (sort === 'recent') {
       const meeting = await Meeting.find({ meetingDate: { $gte: today } })
         .sort({ createdDate: -1 })
-        .skip((page - 1) * 3)
-        .limit(3);
+        .skip((page - 1) * 12)
+        .limit(12);
 
       return res.status(200).send({ meeting, isLastPage });
     }
@@ -61,8 +61,8 @@ exports.featchMeeting = async (req, res) => {
     if (sort === 'view') {
       const meeting = await Meeting.find({ meetingDate: { $gte: today } })
         .sort({ view: -1 })
-        .skip((page - 1) * 3)
-        .limit(3);
+        .skip((page - 1) * 12)
+        .limit(12);
 
       return res.status(200).send({ meeting, isLastPage });
     }


### PR DESCRIPTION
모임 무한 스크롤 요청 시 페이지 마다 기존 3개 데이터 응답에서 12개 응답으로 수정

resolved : #158 